### PR TITLE
Add back-to-home link to list page

### DIFF
--- a/client/src/pages/ListPage.tsx
+++ b/client/src/pages/ListPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { createItem, getList } from "../api";
 import { CartState } from "shared";
 import type { ItemWithDetails, ListWithDetails, PurchaseWithDetails, User } from "shared";
@@ -230,6 +230,14 @@ export default function ListPage() {
 
   return (
     <div className="space-y-6 pb-24 sm:pb-6">
+      {/* Back to home */}
+      <Link
+        to="/"
+        className="inline-flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900"
+      >
+        <span aria-hidden="true">←</span> Back to home
+      </Link>
+
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
         <div>


### PR DESCRIPTION
Closes #2

Adds a '← Back to home' link at the top of the list page so users can return to the home screen without relying on the browser back button or the header logo.