### PR TITLE
Mark purchased items' cartState as purchased

### DIFF
--- a/server/src/routes/purchases.ts
+++ b/server/src/routes/purchases.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { CartState } from "shared";
 import prisma from "../db.js";
 import { createPurchaseSchema, parseIdParam } from "../schemas/index.js";
 import { NotFoundError } from "../middleware/errorHandler.js";
@@ -11,20 +12,41 @@ router.post("/lists/:listId/purchases", async (req, res) => {
   const listId = parseIdParam(req.params.listId, "listId");
   const { payerUserId, items } = createPurchaseSchema.parse(req.body);
 
-  const purchase = await prisma.purchase.create({
-    data: {
-      listId,
-      payerUserId,
-      items: {
-        create: items,
+  const itemIds = items.map((i) => i.itemId);
+
+  const { purchase, updatedItems } = await prisma.$transaction(async (tx) => {
+    const created = await tx.purchase.create({
+      data: {
+        listId,
+        payerUserId,
+        items: { create: items },
       },
-    },
-    include: {
-      items: { include: { item: true } },
-      payer: true,
-    },
+    });
+
+    await tx.item.updateMany({
+      where: { id: { in: itemIds }, cartState: { not: CartState.Purchased } },
+      data: { cartState: CartState.Purchased },
+    });
+
+    const purchase = await tx.purchase.findUniqueOrThrow({
+      where: { id: created.id },
+      include: {
+        items: { include: { item: true } },
+        payer: true,
+      },
+    });
+
+    const updatedItems = await tx.item.findMany({
+      where: { id: { in: itemIds } },
+      include: { exclusions: true, createdBy: true },
+    });
+
+    return { purchase, updatedItems };
   });
 
+  for (const item of updatedItems) {
+    broadcast(listId, { type: "item:updated", payload: item });
+  }
   broadcast(listId, { type: "purchase:created", payload: purchase });
   res.status(201).json(purchase);
 });

--- a/server/src/test/purchases.test.ts
+++ b/server/src/test/purchases.test.ts
@@ -65,6 +65,37 @@ describe("purchases", () => {
         .send({ payerUserId: alice.id, items: [] });
       expect(res.status).toBe(400);
     });
+
+    it("marks purchased items' cartState as 'purchased'", async () => {
+      const { alice, list } = await threeMemberList();
+      const milk = await prisma.item.create({
+        data: { listId: list.id, name: "Milk", createdByUserId: alice.id },
+      });
+      const bread = await prisma.item.create({
+        data: {
+          listId: list.id,
+          name: "Bread",
+          createdByUserId: alice.id,
+          cartState: "inCart",
+        },
+      });
+
+      const res = await request(app)
+        .post(`/api/lists/${list.id}/purchases`)
+        .send({
+          payerUserId: alice.id,
+          items: [
+            { itemId: milk.id, priceCents: 500 },
+            { itemId: bread.id, priceCents: 300 },
+          ],
+        });
+
+      expect(res.status).toBe(201);
+      const stored = await prisma.item.findMany({
+        where: { id: { in: [milk.id, bread.id] } },
+      });
+      expect(stored.every((i) => i.cartState === "purchased")).toBe(true);
+    });
   });
 
   describe("GET /api/lists/:listId/splits", () => {


### PR DESCRIPTION
Closes #3

When a purchase is recorded, every item in it is now flipped to `cartState: "purchased"` server-side (within the same transaction), and each updated item is broadcast as an `item:updated` event so connected clients reflect the new state live.

Added a server test covering the new behavior.