### PR TITLE
Replace split button with participant avatar preview

### DIFF
--- a/client/src/components/ItemRow.test.tsx
+++ b/client/src/components/ItemRow.test.tsx
@@ -123,4 +123,11 @@ describe("ItemRow", () => {
     expect(screen.getByTitle("Edit exclusions")).toBeDisabled();
     expect(screen.getByRole("button", { name: /needed/i })).toBeDisabled();
   });
+
+  it("shows a colored initial avatar for each participating member", () => {
+    renderRow();
+    const avatar = screen.getByTitle("Alice");
+    expect(avatar).toHaveTextContent("A");
+    expect(avatar).toHaveStyle({ backgroundColor: "rgb(79, 70, 229)" });
+  });
 });

--- a/client/src/components/ItemRow.tsx
+++ b/client/src/components/ItemRow.tsx
@@ -72,6 +72,13 @@ export default function ItemRow({
     .map((ex) => members.find((m) => m.userId === ex.userId)?.user.name)
     .filter(Boolean);
 
+  // Members participating in the split = all members minus excluded ones.
+  const excludedIds = new Set(item.exclusions.map((ex) => ex.userId));
+  const participants = members.filter((m) => !excludedIds.has(m.userId));
+  const MAX_AVATARS = 4;
+  const visibleParticipants = participants.slice(0, MAX_AVATARS);
+  const overflow = participants.length - visibleParticipants.length;
+
   return (
     <li
       className={`px-3 py-3 flex items-center gap-3 ${
@@ -118,10 +125,31 @@ export default function ItemRow({
       <button
         onClick={() => onExclusionClick(item)}
         disabled={pending}
-        className="shrink-0 min-h-[44px] min-w-[44px] px-2 text-gray-400 hover:text-indigo-600 text-xs disabled:opacity-50"
+        className="shrink-0 min-h-[44px] flex items-center px-2 disabled:opacity-50 rounded hover:bg-gray-50"
         title="Edit exclusions"
+        aria-label="Edit split participants"
       >
-        split
+        {participants.length === 0 ? (
+          <span className="text-xs text-gray-400">nobody</span>
+        ) : (
+          <div className="flex -space-x-1.5">
+            {visibleParticipants.map((m) => (
+              <span
+                key={m.userId}
+                className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-white text-[10px] font-semibold text-white"
+                style={{ backgroundColor: m.user.color }}
+                title={m.user.name}
+              >
+                {m.user.name.charAt(0).toUpperCase()}
+              </span>
+            ))}
+            {overflow > 0 && (
+              <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-white bg-gray-300 text-[10px] font-semibold text-gray-700">
+                +{overflow}
+              </span>
+            )}
+          </div>
+        )}
       </button>
       <button
         onClick={handleDelete}


### PR DESCRIPTION
Closes #4

Replaces the plain `split` text button on each item row with a stack of small colored circles — one per participating member, each showing the first letter of their name on their personal color. Clicking the stack still opens the exclusion modal. Members excluded from the item are omitted from the preview. Overflowing members beyond 4 collapse into a `+N` badge.