### PR TITLE
Add E2E specs for identity, home, items, search

### DIFF
--- a/e2e/helpers/factories.ts
+++ b/e2e/helpers/factories.ts
@@ -81,10 +81,17 @@ export async function joinAsNewUser(
   await page.waitForURL(/\/list\/\d+/);
 }
 
-/** Add an item via the bottom add-item form. */
+/** Add an item via the bottom add-item form. Waits for the server to acknowledge
+ *  the POST so callers can navigate away without racing the optimistic add. */
 export async function addItemUI(page: Page, name: string): Promise<void> {
   await addItemInput(page).fill(name);
+  const responsePromise = page.waitForResponse(
+    (res) =>
+      /\/api\/lists\/\d+\/items$/.test(res.url()) &&
+      res.request().method() === "POST",
+  );
   await addItemButton(page).click();
+  await responsePromise;
 }
 
 // =========================================================================
@@ -152,4 +159,27 @@ export async function setSavedUser(page: Page, user: User): Promise<void> {
   await page.evaluate((u) => {
     localStorage.setItem("hestia-user", JSON.stringify(u));
   }, user);
+}
+
+/** Seed a user, list, membership, and drop the user on the list page already
+ *  "logged in" via localStorage. Use this when the login/create flow isn't
+ *  what's under test. */
+export async function seedLoggedInOnList(
+  page: Page,
+  request: APIRequestContext,
+  options: { userName: string; listName: string; userColor?: string },
+): Promise<{ user: User; list: List }> {
+  const user = await apiCreateUser(
+    request,
+    options.userName,
+    options.userColor,
+  );
+  const list = await apiCreateList(request, options.listName);
+  await apiAddMember(request, list.id, user.id);
+  // Visit the origin first so localStorage is scoped to it, then seed and go.
+  await page.goto("/");
+  await setSavedUser(page, user);
+  await page.goto(`/list/${list.id}`);
+  await expect(page.getByRole("heading", { name: options.listName })).toBeVisible();
+  return { user, list };
 }

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "./fixtures.js";
+import { addItemUI, createListUI, loginAs } from "./helpers/factories.js";
+
+test.describe("home", () => {
+  test("list-name input is disabled and prompts a login when logged out", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const input = page.getByPlaceholder("Log in first");
+    await expect(input).toBeVisible();
+    await expect(input).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: /^create$/i }),
+    ).toBeDisabled();
+  });
+
+  test("creating a list redirects to it and auto-adds the creator as a member", async ({
+    page,
+  }) => {
+    await loginAs(page, "Alice");
+    await page.getByPlaceholder(/weekly groceries/i).fill("Weekend trip");
+    await page.getByRole("button", { name: /^create$/i }).click();
+
+    await page.waitForURL(/\/list\/\d+/);
+    await expect(
+      page.getByRole("heading", { name: "Weekend trip" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /view members/i }),
+    ).toContainText("1 member");
+  });
+
+  test("a brand-new user sees the empty My Lists state", async ({ page }) => {
+    await loginAs(page, "Alice");
+    await expect(page.getByText("No lists yet")).toBeVisible();
+  });
+
+  test("a created list appears in My Lists with member and item counts", async ({
+    page,
+  }) => {
+    await loginAs(page, "Alice");
+    await createListUI(page, "Pantry");
+
+    await page.getByRole("link", { name: /back to home/i }).click();
+    await page.waitForURL("http://localhost:5174/");
+
+    const card = page.getByRole("link", { name: /pantry/i });
+    await expect(card).toBeVisible();
+    await expect(card).toContainText("1 member");
+    await expect(card).toContainText("0 items");
+  });
+
+  test("item count updates on the home card after returning from the list", async ({
+    page,
+  }) => {
+    await loginAs(page, "Alice");
+    await createListUI(page, "Pantry");
+
+    await addItemUI(page, "Milk");
+    await expect(page.getByText("Milk")).toBeVisible();
+
+    await page.getByRole("link", { name: /back to home/i }).click();
+    await page.waitForURL("http://localhost:5174/");
+
+    await expect(page.getByRole("link", { name: /pantry/i })).toContainText(
+      "1 item",
+    );
+  });
+});

--- a/e2e/identity.spec.ts
+++ b/e2e/identity.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("identity", () => {
+  test("logs in with a non-default color and shows a swatch in that color", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByPlaceholder("Your name").fill("Alice");
+    // Pick the red swatch — color buttons expose their hex via aria-label.
+    await page.getByRole("button", { name: "#dc2626" }).click();
+    await page.getByRole("button", { name: /^log in$/i }).click();
+
+    // Identity card visible.
+    const logout = page.getByRole("button", { name: /log out/i });
+    await expect(logout).toBeVisible();
+
+    // The swatch span sits next to the name in the identity card; assert its
+    // computed background-color matches the picked hex.
+    const swatch = page
+      .locator("span.rounded-full")
+      .filter({ hasNotText: "Alice" })
+      .first();
+    await expect(swatch).toHaveCSS("background-color", "rgb(220, 38, 38)");
+  });
+
+  test("identity persists across a full page reload", async ({ page }) => {
+    await page.goto("/");
+    await page.getByPlaceholder("Your name").fill("Alice");
+    await page.getByRole("button", { name: /^log in$/i }).click();
+    await expect(page.getByRole("button", { name: /log out/i })).toBeVisible();
+
+    await page.reload();
+
+    // Login form should be gone; logout button still here.
+    await expect(page.getByRole("button", { name: /log out/i })).toBeVisible();
+    await expect(page.getByPlaceholder("Your name")).toHaveCount(0);
+  });
+
+  test("logging out clears localStorage and re-shows the login form", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByPlaceholder("Your name").fill("Alice");
+    await page.getByRole("button", { name: /^log in$/i }).click();
+    await expect(page.getByRole("button", { name: /log out/i })).toBeVisible();
+
+    await page.getByRole("button", { name: /log out/i }).click();
+
+    await expect(page.getByPlaceholder("Your name")).toBeVisible();
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("hestia-user"),
+    );
+    expect(stored).toBeNull();
+  });
+
+  test("Log in button is disabled for empty or whitespace names", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const button = page.getByRole("button", { name: /^log in$/i });
+    await expect(button).toBeDisabled();
+
+    await page.getByPlaceholder("Your name").fill("   ");
+    await expect(button).toBeDisabled();
+
+    await page.getByPlaceholder("Your name").fill("Alice");
+    await expect(button).toBeEnabled();
+  });
+});

--- a/e2e/items.spec.ts
+++ b/e2e/items.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "./fixtures.js";
+import {
+  addItemUI,
+  apiAddItem,
+  seedLoggedInOnList,
+} from "./helpers/factories.js";
+
+test.describe("items", () => {
+  test("an added item appears with author credit in the user's color", async ({
+    page,
+    request,
+  }) => {
+    await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+      userColor: "#dc2626", // red — distinct so the color check is meaningful
+    });
+
+    await addItemUI(page, "Milk");
+
+    const milkRow = page.getByRole("listitem").filter({ hasText: "Milk" });
+    await expect(milkRow).toBeVisible();
+
+    // The "by Alice" credit's inner span carries the user's color.
+    const alice = milkRow.locator("span", { hasText: /^Alice$/ });
+    await expect(alice.first()).toHaveCSS("color", "rgb(220, 38, 38)");
+  });
+
+  test("clicking the state badge cycles needed → in cart → purchased → needed", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", user.id);
+
+    const milkRow = page.getByRole("listitem").filter({ hasText: "Milk" });
+    await expect(milkRow).toBeVisible();
+    const badge = milkRow.getByTitle(/currently:/i);
+
+    await expect(badge).toHaveText("needed");
+    await badge.click();
+    await expect(badge).toHaveText("in cart");
+    await badge.click();
+    await expect(badge).toHaveText("purchased");
+    // Item name now line-through.
+    await expect(milkRow.getByText("Milk")).toHaveClass(/line-through/);
+    await badge.click();
+    await expect(badge).toHaveText("needed");
+  });
+
+  test("purchased items render under the Purchased group", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Cookies", user.id);
+    await page.reload();
+
+    // Cycle Cookies to purchased (needed → inCart → purchased).
+    const row = page.getByRole("listitem").filter({ hasText: "Cookies" });
+    const badge = row.getByTitle(/currently:/i);
+    await badge.click();
+    await badge.click();
+    await expect(badge).toHaveText("purchased");
+
+    await expect(
+      page.getByRole("button", { name: /purchased \(1\)/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /needed \(\d+\)/i }),
+    ).toHaveCount(0);
+  });
+
+  test("group collapse state survives interacting with another group", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", user.id);
+    await apiAddItem(request, list.id, "Bread", user.id);
+    await page.reload();
+
+    const neededHeader = page.getByRole("button", { name: /needed \(2\)/i });
+    await expect(neededHeader).toHaveAttribute("aria-expanded", "true");
+
+    await neededHeader.click();
+    await expect(neededHeader).toHaveAttribute("aria-expanded", "false");
+
+    // Add another item — collapse state for "Needed" should persist.
+    await addItemUI(page, "Eggs");
+    // Wait for the count to bump to 3, and the collapsed flag to remain.
+    await expect(
+      page.getByRole("button", { name: /needed \(3\)/i }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("deleting an item removes it and shows an Item removed toast", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", user.id);
+    await page.reload();
+
+    const row = page.getByRole("listitem").filter({ hasText: "Milk" });
+    await row.getByTitle("Delete item").click();
+
+    await expect(page.getByRole("status")).toHaveText("Item removed");
+    await expect(page.getByText("Milk")).toHaveCount(0);
+  });
+
+  test("an empty list shows the No items yet card", async ({
+    page,
+    request,
+  }) => {
+    await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await expect(page.getByText("No items yet")).toBeVisible();
+  });
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "./fixtures.js";
+import { apiAddItem, seedLoggedInOnList } from "./helpers/factories.js";
+
+test.describe("search", () => {
+  test("search bar only renders when there are items", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+
+    await expect(page.getByPlaceholder("Search items...")).toHaveCount(0);
+
+    await apiAddItem(request, list.id, "Milk", user.id);
+    await expect(page.getByPlaceholder("Search items...")).toBeVisible();
+  });
+
+  test("typing filters items live with case-insensitive substring match", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Apples", user.id);
+    await apiAddItem(request, list.id, "Bananas", user.id);
+    await apiAddItem(request, list.id, "Pineapple", user.id);
+    await page.reload();
+
+    const search = page.getByPlaceholder("Search items...");
+    await search.fill("APPL");
+
+    await expect(page.getByText("Apples")).toBeVisible();
+    await expect(page.getByText("Pineapple")).toBeVisible();
+    await expect(page.getByText("Bananas")).toHaveCount(0);
+  });
+
+  test("shows an empty-state card when nothing matches the query", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", user.id);
+    await page.reload();
+
+    await page.getByPlaceholder("Search items...").fill("zzz");
+    await expect(page.getByText(/no items match/i)).toBeVisible();
+    // The empty-state copy quotes the query with Unicode curly quotes; match
+    // the query loosely rather than depending on the exact glyphs.
+    await expect(page.getByText(/zzz/)).toBeVisible();
+  });
+
+  test("collapsed groups are forced open while a search query is active", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Apples", user.id);
+    await apiAddItem(request, list.id, "Bread", user.id);
+    await page.reload();
+
+    // The header label includes the group count, which shifts as the search
+    // narrows the list. Match by prefix only.
+    const neededHeader = page.getByRole("button", { name: /^needed \(/i });
+    await neededHeader.click();
+    await expect(neededHeader).toHaveAttribute("aria-expanded", "false");
+
+    await page.getByPlaceholder("Search items...").fill("appl");
+    await expect(neededHeader).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByText("Apples")).toBeVisible();
+  });
+
+  test("clearing via the × button restores the full list", async ({
+    page,
+    request,
+  }) => {
+    const { user, list } = await seedLoggedInOnList(page, request, {
+      userName: "Alice",
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Apples", user.id);
+    await apiAddItem(request, list.id, "Bread", user.id);
+    await page.reload();
+
+    const search = page.getByPlaceholder("Search items...");
+    await search.fill("appl");
+    await expect(page.getByText("Bread")).toHaveCount(0);
+
+    await page.getByRole("button", { name: /clear search/i }).click();
+    await expect(search).toHaveValue("");
+    await expect(page.getByText("Apples")).toBeVisible();
+    await expect(page.getByText("Bread")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #19.

## Summary
- Four single-context spec files (`identity.spec.ts`, `home.spec.ts`, `items.spec.ts`, `search.spec.ts`) covering the core single-user flows on the list app: login + identity persistence, home-page list creation and listing, item CRUD + state cycling + grouping, and the search bar.
- New `seedLoggedInOnList` helper that API-seeds a user, list, and membership, then drops the page on `/list/:id` with localStorage pre-populated — used by the items and search specs since the login flow isn't what's under test.
- `addItemUI` now awaits the POST response so callers can navigate away safely without racing the optimistic add (was the source of a flake on the home spec).

## Notes for future spec authors
- Group-collapse animations use `grid-template-rows: 0fr` + `overflow-hidden`. Playwright's `toBeVisible` reports those rows as visible because the element's bounding box is its natural pre-clip size. Assert against the header's `aria-expanded` attribute instead.
- The cart-state badge has no `aria-label`; its accessible name is its text content. Use `getByTitle(/currently:/i)` to target it specifically.

## Test plan
- [x] `npm run typecheck` — clean.
- [x] `npm test` — all unit tests pass.
- [x] `npm run test:e2e` — 23 tests pass (4 existing + 19 new), three consecutive runs ~22s each, no flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)