### PR TITLE
Add E2E specs for exclusions, checkout, and splits

### DIFF
--- a/e2e/checkout.spec.ts
+++ b/e2e/checkout.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, type Page } from "./fixtures.js";
+import {
+  apiAddItem,
+  apiUpdateItem,
+  seedListWithMembers,
+} from "./helpers/factories.js";
+
+/** Locate the Record-Purchase modal container. The modal heading and the
+ *  page-level trigger button share the same text "Record Purchase", so we
+ *  scope by walking up from the modal's heading element. */
+function checkoutModal(page: Page) {
+  return page
+    .getByRole("heading", { name: "Record Purchase" })
+    .locator("../..");
+}
+
+test.describe("checkout", () => {
+  test("items already in 'purchased' state are pre-selected when the modal opens", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    const milk = await apiAddItem(request, list.id, "Milk", owner.id);
+    await apiAddItem(request, list.id, "Bread", owner.id);
+    await apiUpdateItem(request, milk.id, { cartState: "purchased" });
+    await page.reload();
+
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    const modal = checkoutModal(page);
+
+    await expect(
+      modal.getByRole("listitem").filter({ hasText: "Milk" }).getByRole("checkbox"),
+    ).toBeChecked();
+    await expect(
+      modal.getByRole("listitem").filter({ hasText: "Bread" }).getByRole("checkbox"),
+    ).not.toBeChecked();
+  });
+
+  test("submitting with a blank price for a selected item shows an inline error", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    const modal = checkoutModal(page);
+    await modal
+      .getByRole("listitem")
+      .filter({ hasText: "Milk" })
+      .getByRole("checkbox")
+      .check();
+    // Leave the price blank.
+    await modal.getByRole("button", { name: "Record Purchase" }).click();
+
+    await expect(modal).toContainText(
+      /enter a price for every selected item/i,
+    );
+  });
+
+  test("submitting with a $0 price reports it by item name", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    const modal = checkoutModal(page);
+    const milkRow = modal.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow.getByRole("checkbox").check();
+    await milkRow.getByPlaceholder("0.00").fill("0");
+    await modal.getByRole("button", { name: "Record Purchase" }).click();
+
+    await expect(modal).toContainText(/invalid price for "milk"/i);
+  });
+
+  test("the submit button is disabled when nothing is selected", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    const modal = checkoutModal(page);
+    const submit = modal.getByRole("button", { name: "Record Purchase" });
+    // Nothing's pre-selected (Milk is in 'needed' state).
+    await expect(submit).toBeDisabled();
+
+    // Selecting then deselecting brings us back to disabled.
+    const milkCheckbox = modal
+      .getByRole("listitem")
+      .filter({ hasText: "Milk" })
+      .getByRole("checkbox");
+    await milkCheckbox.check();
+    await expect(submit).toBeEnabled();
+    await milkCheckbox.uncheck();
+    await expect(submit).toBeDisabled();
+  });
+
+  test("selecting a different payer records the purchase under their id", async ({
+    page,
+    request,
+  }) => {
+    const { owner, others, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    const bob = others[0];
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    const modal = checkoutModal(page);
+
+    // Default payer is the current user, marked "(you)".
+    const payerSelect = modal.locator("select");
+    await expect(payerSelect).toHaveValue(String(owner.id));
+    await expect(payerSelect.locator("option:checked")).toContainText("(you)");
+
+    // Switch to Bob and submit.
+    await payerSelect.selectOption(String(bob.id));
+    const milkRow = modal.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow.getByRole("checkbox").check();
+    await milkRow.getByPlaceholder("0.00").fill("4.00");
+    await modal.getByRole("button", { name: "Record Purchase" }).click();
+
+    // Modal closes; toast appears.
+    await expect(
+      page.getByRole("heading", { name: "Record Purchase" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("status")).toContainText("Purchase recorded");
+
+    // Verify on the server side that the payer is Bob.
+    const purchases = await request
+      .get(`/api/lists/${list.id}/purchases`)
+      .then((r) => r.json());
+    expect(purchases).toHaveLength(1);
+    expect(purchases[0].payerUserId).toBe(bob.id);
+  });
+
+  test("a successful submission closes the modal, fires a toast, and reveals the splits chip", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    const modal = checkoutModal(page);
+    const milkRow = modal.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow.getByRole("checkbox").check();
+    await milkRow.getByPlaceholder("0.00").fill("5.00");
+    await modal.getByRole("button", { name: "Record Purchase" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Record Purchase" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("status")).toContainText("Purchase recorded");
+    await expect(
+      page.getByRole("button", { name: /view splits \(\$5\.00 total\)/i }),
+    ).toBeVisible();
+  });
+
+  test("reopening checkout for a previously priced item pre-fills under 'Already recorded'", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    // First purchase: $5.00.
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    let modal = checkoutModal(page);
+    const milkRow = () =>
+      modal.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow().getByRole("checkbox").check();
+    await milkRow().getByPlaceholder("0.00").fill("5.00");
+    await modal.getByRole("button", { name: "Record Purchase" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Record Purchase" }),
+    ).toHaveCount(0);
+
+    // Reopen — Milk lives under "Already recorded" with the prior price.
+    await page.getByRole("button", { name: "Record Purchase" }).click();
+    modal = checkoutModal(page);
+    await expect(modal).toContainText(/already recorded/i);
+    const reopenedRow = modal.getByRole("listitem").filter({ hasText: "Milk" });
+    // Pre-selected because cartState flipped to purchased.
+    await expect(reopenedRow.getByRole("checkbox")).toBeChecked();
+    await expect(reopenedRow.getByPlaceholder("0.00")).toHaveValue("5.00");
+  });
+});

--- a/e2e/exclusions.spec.ts
+++ b/e2e/exclusions.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "./fixtures.js";
+import { apiAddItem, seedListWithMembers } from "./helpers/factories.js";
+
+test.describe("exclusions", () => {
+  test("opening the exclusion modal lists every member as a checkbox", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    const milkRow = page.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow.getByLabel("Edit split participants").click();
+
+    await expect(
+      page.getByRole("heading", { name: /split: milk/i }),
+    ).toBeVisible();
+
+    const modal = page
+      .getByRole("heading", { name: /split: milk/i })
+      .locator("../..");
+    await expect(modal.getByRole("checkbox")).toHaveCount(2);
+    await expect(
+      modal.getByRole("checkbox", { name: /alice/i }),
+    ).toBeChecked();
+    await expect(
+      modal.getByRole("checkbox", { name: /bob/i }),
+    ).toBeChecked();
+  });
+
+  test("excluding a member shows the not-<name> badge and reduces the avatar count", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    const milkRow = page.getByRole("listitem").filter({ hasText: "Milk" });
+    const avatarsButton = milkRow.getByLabel("Edit split participants");
+    // Initial: 2 participant avatars (Alice, Bob).
+    await expect(avatarsButton.locator("span.rounded-full")).toHaveCount(2);
+
+    await avatarsButton.click();
+    const modal = page
+      .getByRole("heading", { name: /split: milk/i })
+      .locator("../..");
+    // The checkbox is controlled and only flips after the API resolves, so
+    // .uncheck()'s post-condition assertion would race the network round-trip.
+    // Use a plain click and confirm the visible "excluded" tag instead.
+    await modal.getByRole("checkbox", { name: /bob/i }).click();
+    await expect(modal.locator("li").filter({ hasText: /bob/i })).toContainText(
+      /excluded/i,
+    );
+    await modal.getByRole("button", { name: /^done$/i }).click();
+
+    await expect(milkRow).toContainText(/not bob/i);
+    await expect(avatarsButton.locator("span.rounded-full")).toHaveCount(1);
+  });
+
+  test("re-checking a previously excluded member removes the badge", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    const milkRow = page.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow.getByLabel("Edit split participants").click();
+
+    const modal = page
+      .getByRole("heading", { name: /split: milk/i })
+      .locator("../..");
+    const bob = modal.getByRole("checkbox", { name: /bob/i });
+    const bobRow = modal.locator("li").filter({ hasText: /bob/i });
+    await bob.click();
+    await expect(bobRow).toContainText(/excluded/i);
+    await bob.click();
+    await expect(modal.getByText(/excluded/i)).toHaveCount(0);
+    await modal.getByRole("button", { name: /^done$/i }).click();
+
+    await expect(milkRow).not.toContainText(/not bob/i);
+  });
+
+  test("excluding every member shows 'nobody' instead of avatars", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    const milkRow = page.getByRole("listitem").filter({ hasText: "Milk" });
+    await milkRow.getByLabel("Edit split participants").click();
+
+    const modal = page
+      .getByRole("heading", { name: /split: milk/i })
+      .locator("../..");
+    await modal.getByRole("checkbox", { name: /alice/i }).click();
+    // Wait for the first toggle to settle before issuing the next one — the
+    // saving-state lock disables the disabled prop on a single row at a time.
+    await expect(
+      modal.locator("li").filter({ hasText: /alice/i }),
+    ).toContainText(/excluded/i);
+    await modal.getByRole("checkbox", { name: /bob/i }).click();
+    await expect(modal.getByText(/excluded/i)).toHaveCount(2);
+    await modal.getByRole("button", { name: /^done$/i }).click();
+
+    const avatarsButton = milkRow.getByLabel("Edit split participants");
+    await expect(avatarsButton).toContainText(/nobody/i);
+    await expect(avatarsButton.locator("span.rounded-full")).toHaveCount(0);
+  });
+});

--- a/e2e/helpers/factories.ts
+++ b/e2e/helpers/factories.ts
@@ -152,6 +152,51 @@ export async function apiAddItem(
   return res.json();
 }
 
+export async function apiUpdateItem(
+  request: APIRequestContext,
+  itemId: number,
+  data: { cartState?: string; name?: string },
+): Promise<Item> {
+  const res = await request.patch(`/api/items/${itemId}`, { data });
+  expect(
+    res.ok(),
+    `apiUpdateItem ${itemId} failed: ${res.status()}`,
+  ).toBeTruthy();
+  return res.json();
+}
+
+export async function apiAddExclusion(
+  request: APIRequestContext,
+  itemId: number,
+  userId: number,
+): Promise<void> {
+  const res = await request.post(`/api/items/${itemId}/exclusions`, {
+    data: { userId },
+  });
+  expect(
+    res.ok(),
+    `apiAddExclusion item=${itemId} user=${userId} failed: ${res.status()}`,
+  ).toBeTruthy();
+}
+
+export async function apiCreatePurchase(
+  request: APIRequestContext,
+  listId: number,
+  payload: {
+    payerUserId: number;
+    items: { itemId: number; priceCents: number }[];
+  },
+): Promise<unknown> {
+  const res = await request.post(`/api/lists/${listId}/purchases`, {
+    data: payload,
+  });
+  expect(
+    res.ok(),
+    `apiCreatePurchase on list ${listId} failed: ${res.status()}`,
+  ).toBeTruthy();
+  return res.json();
+}
+
 /** Write a saved-user blob to localStorage so the page treats this user as
  *  logged in without going through the UI login flow. Must be called after
  *  navigating to the app origin (otherwise localStorage is scoped to about:blank). */
@@ -182,4 +227,31 @@ export async function seedLoggedInOnList(
   await page.goto(`/list/${list.id}`);
   await expect(page.getByRole("heading", { name: options.listName })).toBeVisible();
   return { user, list };
+}
+
+/** Seed an owner + N other members on a list, leaving the page on the list
+ *  view as the owner. Use for specs that need a multi-member context but
+ *  don't care about the join flow. */
+export async function seedListWithMembers(
+  page: Page,
+  request: APIRequestContext,
+  options: {
+    ownerName: string;
+    otherNames: string[];
+    listName: string;
+    ownerColor?: string;
+  },
+): Promise<{ owner: User; others: User[]; list: List }> {
+  const { user: owner, list } = await seedLoggedInOnList(page, request, {
+    userName: options.ownerName,
+    listName: options.listName,
+    userColor: options.ownerColor,
+  });
+  const others: User[] = [];
+  for (const name of options.otherNames) {
+    const u = await apiCreateUser(request, name);
+    await apiAddMember(request, list.id, u.id);
+    others.push(u);
+  }
+  return { owner, others, list };
 }

--- a/e2e/splits.spec.ts
+++ b/e2e/splits.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from "./fixtures.js";
+import {
+  apiAddExclusion,
+  apiAddItem,
+  apiCreatePurchase,
+  seedListWithMembers,
+} from "./helpers/factories.js";
+
+test.describe("splits", () => {
+  test("the splits chip is hidden when no purchases exist", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob", "Carol"],
+      listName: "Trip",
+    });
+    await apiAddItem(request, list.id, "Milk", owner.id);
+    await page.reload();
+
+    await expect(
+      page.getByRole("button", { name: /view splits/i }),
+    ).toHaveCount(0);
+  });
+
+  test("after a single purchase the chip shows the total and the modal lists owes-rows", async ({
+    page,
+    request,
+  }) => {
+    const { owner, others, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob", "Carol"],
+      listName: "Trip",
+    });
+    const milk = await apiAddItem(request, list.id, "Milk", owner.id);
+
+    // Alice pays $9 split 3 ways → Bob and Carol each owe Alice $3.
+    await apiCreatePurchase(request, list.id, {
+      payerUserId: owner.id,
+      items: [{ itemId: milk.id, priceCents: 900 }],
+    });
+    await page.reload();
+
+    const chip = page.getByRole("button", {
+      name: /view splits \(\$9\.00 total\)/i,
+    });
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    const splitsModal = page
+      .getByRole("heading", { name: "Cost Splitting" })
+      .locator("../..");
+    const rows = splitsModal.getByRole("listitem");
+    await expect(rows).toHaveCount(2);
+
+    const bob = others[0];
+    const carol = others[1];
+    await expect(splitsModal).toContainText(bob.name);
+    await expect(splitsModal).toContainText(carol.name);
+    // Both rows show $3.00 owed to Alice.
+    await expect(rows.filter({ hasText: bob.name })).toContainText("$3.00");
+    await expect(rows.filter({ hasText: carol.name })).toContainText("$3.00");
+  });
+
+  test("an excluded member doesn't appear in the item's debt graph", async ({
+    page,
+    request,
+  }) => {
+    const { owner, others, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob", "Carol"],
+      listName: "Trip",
+    });
+    const milk = await apiAddItem(request, list.id, "Milk", owner.id);
+
+    // Carol is excluded from Milk; Alice pays $10. Splits 2 ways → Bob owes Alice $5.
+    await apiAddExclusion(request, milk.id, others[1].id); // Carol
+    await apiCreatePurchase(request, list.id, {
+      payerUserId: owner.id,
+      items: [{ itemId: milk.id, priceCents: 1000 }],
+    });
+    await page.reload();
+
+    await page
+      .getByRole("button", { name: /view splits \(\$10\.00 total\)/i })
+      .click();
+    const splitsModal = page
+      .getByRole("heading", { name: "Cost Splitting" })
+      .locator("../..");
+
+    const rows = splitsModal.getByRole("listitem");
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText(others[0].name); // Bob
+    await expect(rows.first()).toContainText("$5.00");
+    await expect(splitsModal).not.toContainText(others[1].name); // Carol absent
+  });
+
+  test("two purchases by different payers net out and drop settled members", async ({
+    page,
+    request,
+  }) => {
+    const { owner, others, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob", "Carol"],
+      listName: "Trip",
+    });
+    const bob = others[0];
+    const carol = others[1];
+    const milk = await apiAddItem(request, list.id, "Milk", owner.id);
+    const bread = await apiAddItem(request, list.id, "Bread", owner.id);
+
+    // Alice pays $9 for milk → Bob owes Alice $3, Carol owes Alice $3.
+    await apiCreatePurchase(request, list.id, {
+      payerUserId: owner.id,
+      items: [{ itemId: milk.id, priceCents: 900 }],
+    });
+    // Bob pays $9 for bread → Alice owes Bob $3, Carol owes Bob $3.
+    // Net: Alice ↔ Bob settles. Carol owes Alice $3 and owes Bob $3.
+    await apiCreatePurchase(request, list.id, {
+      payerUserId: bob.id,
+      items: [{ itemId: bread.id, priceCents: 900 }],
+    });
+    await page.reload();
+
+    await page
+      .getByRole("button", { name: /view splits \(\$18\.00 total\)/i })
+      .click();
+    const splitsModal = page
+      .getByRole("heading", { name: "Cost Splitting" })
+      .locator("../..");
+    const rows = splitsModal.getByRole("listitem");
+    await expect(rows).toHaveCount(2);
+
+    // Each row should be Carol owing $3 — once to Alice, once to Bob.
+    const carolRows = rows.filter({ hasText: carol.name });
+    await expect(carolRows).toHaveCount(2);
+    await expect(carolRows.first()).toContainText("$3.00");
+    await expect(carolRows.last()).toContainText("$3.00");
+    // Alice ↔ Bob row absent (settled): no row contains both names.
+    await expect(
+      rows.filter({ hasText: owner.name }).filter({ hasText: bob.name }),
+    ).toHaveCount(0);
+  });
+
+  test("the splits modal closes via × and via the backdrop", async ({
+    page,
+    request,
+  }) => {
+    const { owner, list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob"],
+      listName: "Trip",
+    });
+    const milk = await apiAddItem(request, list.id, "Milk", owner.id);
+    await apiCreatePurchase(request, list.id, {
+      payerUserId: owner.id,
+      items: [{ itemId: milk.id, priceCents: 600 }],
+    });
+    await page.reload();
+
+    const chip = page.getByRole("button", { name: /view splits/i });
+
+    // × button closes.
+    await chip.click();
+    await expect(
+      page.getByRole("heading", { name: "Cost Splitting" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: /close splits/i }).click();
+    await expect(
+      page.getByRole("heading", { name: "Cost Splitting" }),
+    ).toHaveCount(0);
+
+    // Backdrop click closes.
+    await chip.click();
+    await expect(
+      page.getByRole("heading", { name: "Cost Splitting" }),
+    ).toBeVisible();
+    // Click the backdrop in the top-left corner — the modal occupies the
+    // center of the viewport and would intercept a center click.
+    await page.locator("div.bg-black\\/40").click({ position: { x: 5, y: 5 } });
+    await expect(
+      page.getByRole("heading", { name: "Cost Splitting" }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #20.

## Summary
- Three multi-member spec files (`exclusions.spec.ts`, `checkout.spec.ts`, `splits.spec.ts`) covering the entire cost-splitting workflow: who's in/out of an item's split, recording a purchase end-to-end, and how the resulting debt graph renders.
- New API factories: `apiUpdateItem`, `apiAddExclusion`, `apiCreatePurchase`.
- New `seedListWithMembers` helper that seeds an owner + N other members and drops the page on the list view as the owner — used as the standard setup across all three files.

## Notes for future spec authors
- The exclusion-modal checkbox is React-controlled: its `checked` prop only flips after the optimistic API call resolves. `.uncheck()` / `.check()` fail their internal post-condition assertion. Use `.click()` and assert on the visible "excluded" tag (or `.toBeChecked()` which retries) instead.
- Modal backdrop locators (`div.bg-black/40`) cover the whole viewport, but the modal sits at the geometric center where Playwright clicks by default. Pass `position: { x, y }` to click a corner, otherwise the modal content intercepts the pointer.
- The page-level "Record Purchase" trigger and the modal's submit button share the same accessible name. Scope to the modal by walking up from its heading (same pattern as `flow.spec.ts`).

## Test plan
- [x] `npm run typecheck` — clean across both workspaces.
- [x] `npm test` — 18 client + 41 server tests pass, unchanged.
- [x] `npm run test:e2e` — 39 tests pass (23 existing + 16 new), two consecutive runs ~45s each, no flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)