### PR TITLE
Add E2E specs for realtime, members, share-and-join, and errors

### DIFF
--- a/e2e/errors.spec.ts
+++ b/e2e/errors.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "./fixtures.js";
+import {
+  apiAddMember,
+  apiCreateList,
+  apiCreateUser,
+} from "./helpers/factories.js";
+
+test.describe("error states", () => {
+  test("navigating to a non-existent list ID renders the error block", async ({
+    page,
+  }) => {
+    await page.goto("/list/999999");
+    // ListPage renders <p className="text-red-600 font-medium">{err.message}</p>;
+    // the server-side NotFoundError formats as "List 999999 not found".
+    await expect(page.getByText(/list 999999 not found/i)).toBeVisible();
+  });
+
+  test("navigating to an invalid share token renders the invalid-link error", async ({
+    page,
+  }) => {
+    await page.goto("/join/not-a-real-token");
+    await expect(
+      page.getByText(/this share link may be invalid or expired/i),
+    ).toBeVisible();
+  });
+
+  test("direct navigation to /list/:id while logged out loads but disables the add bar", async ({
+    page,
+    request,
+  }) => {
+    const alice = await apiCreateUser(request, "Alice");
+    const list = await apiCreateList(request, "Trip");
+    await apiAddMember(request, list.id, alice.id);
+
+    // Don't seed any user into localStorage.
+    await page.goto(`/list/${list.id}`);
+
+    await expect(page.getByRole("heading", { name: "Trip" })).toBeVisible();
+    const addBar = page.getByPlaceholder("Join the list to add items");
+    await expect(addBar).toBeVisible();
+    await expect(addBar).toBeDisabled();
+    // Record-Purchase button is gated on currentUserId, so it should be absent.
+    await expect(
+      page.getByRole("button", { name: "Record Purchase" }),
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/helpers/factories.ts
+++ b/e2e/helpers/factories.ts
@@ -1,4 +1,9 @@
-import { expect, type APIRequestContext, type Page } from "@playwright/test";
+import {
+  expect,
+  type APIRequestContext,
+  type Browser,
+  type Page,
+} from "@playwright/test";
 import {
   addItemButton,
   addItemInput,
@@ -227,6 +232,49 @@ export async function seedLoggedInOnList(
   await page.goto(`/list/${list.id}`);
   await expect(page.getByRole("heading", { name: options.listName })).toBeVisible();
   return { user, list };
+}
+
+/** Open a fresh browser context, seed the user into localStorage, and land
+ *  on `/list/:id` with the WebSocket fully connected.
+ *
+ *  Why the WS dance: cross-context realtime tests trigger API mutations and
+ *  expect the *other* page to receive the broadcast. The server only
+ *  broadcasts to currently-connected sockets, so if the API call lands
+ *  before the receiver's WS handshake completes the event is silently
+ *  dropped. We monkey-patch the page's `WebSocket` constructor to expose an
+ *  "opened" promise and await it before returning. */
+export async function pageAsMember(
+  browser: Browser,
+  user: User,
+  list: { id: number; name: string },
+): Promise<Page> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.addInitScript(() => {
+    const OriginalWS = window.WebSocket;
+    let resolveOpened: (() => void) | null = null;
+    (window as unknown as { __hestiaWsOpened: Promise<void> }).__hestiaWsOpened =
+      new Promise<void>((r) => {
+        resolveOpened = r;
+      });
+    class PatchedWS extends OriginalWS {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        super(url, protocols);
+        this.addEventListener("open", () => resolveOpened?.());
+      }
+    }
+    (window as unknown as { WebSocket: typeof WebSocket }).WebSocket = PatchedWS;
+  });
+  await page.goto("/");
+  await setSavedUser(page, user);
+  await page.goto(`/list/${list.id}`);
+  await page.getByRole("heading", { name: list.name }).waitFor();
+  await page.evaluate(
+    () =>
+      (window as unknown as { __hestiaWsOpened: Promise<void> })
+        .__hestiaWsOpened,
+  );
+  return page;
 }
 
 /** Seed an owner + N other members on a list, leaving the page on the list

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "./fixtures.js";
+import {
+  apiAddMember,
+  apiCreateList,
+  apiCreateUser,
+  seedListWithMembers,
+  setSavedUser,
+} from "./helpers/factories.js";
+
+test.describe("members", () => {
+  test("the header avatar cluster shows the first 4 + an overflow chip", async ({
+    page,
+    request,
+  }) => {
+    // 6 members → 4 visible avatars + a "+2" overflow chip.
+    const { list } = await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob", "Carol", "Dave", "Eve", "Frank"],
+      listName: "Trip",
+    });
+    void list;
+
+    const cluster = page.getByRole("button", { name: /view members/i });
+    // 4 named-avatars + 1 overflow chip = 5 rounded spans inside the cluster.
+    await expect(cluster.locator("span.rounded-full")).toHaveCount(5);
+    await expect(cluster).toContainText("+2");
+    await expect(cluster).toContainText("6 members");
+  });
+
+  test("opening MembersModal lists every member with the current user marked '(you)'", async ({
+    page,
+    request,
+  }) => {
+    await seedListWithMembers(page, request, {
+      ownerName: "Alice",
+      otherNames: ["Bob", "Carol"],
+      listName: "Trip",
+    });
+
+    await page.getByRole("button", { name: /view members/i }).click();
+
+    const modal = page
+      .getByRole("heading", { name: "Members" })
+      .locator("../..");
+    await expect(modal.getByRole("listitem")).toHaveCount(3);
+    await expect(
+      modal.getByRole("listitem").filter({ hasText: "Alice" }),
+    ).toContainText("(you)");
+    await expect(
+      modal.getByRole("listitem").filter({ hasText: "Bob" }),
+    ).not.toContainText("(you)");
+  });
+
+  test("Leave list: confirm dialog → user is navigated home and the list disappears from My Lists", async ({
+    browser,
+    request,
+  }) => {
+    const alice = await apiCreateUser(request, "Alice");
+    const bob = await apiCreateUser(request, "Bob");
+    const list = await apiCreateList(request, "Trip");
+    await apiAddMember(request, list.id, alice.id);
+    await apiAddMember(request, list.id, bob.id);
+
+    // Drop Bob on the list page.
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto("/");
+    await setSavedUser(page, bob);
+    await page.goto(`/list/${list.id}`);
+    await expect(page.getByRole("heading", { name: "Trip" })).toBeVisible();
+
+    await page.getByRole("button", { name: /view members/i }).click();
+    page.once("dialog", (dialog) => dialog.accept());
+    await page.getByRole("button", { name: /^leave list$/i }).click();
+
+    await page.waitForURL(/\/$/);
+    // Bob should no longer see Trip in his My Lists.
+    await expect(page.getByRole("link", { name: /trip/i })).toHaveCount(0);
+
+    // Server should also report Bob as no longer a member.
+    const after = await request
+      .get(`/api/users/${bob.id}/lists`)
+      .then((r) => r.json());
+    expect(after).toEqual([]);
+  });
+});

--- a/e2e/realtime.spec.ts
+++ b/e2e/realtime.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "./fixtures.js";
+import {
+  apiAddItem,
+  apiAddMember,
+  apiCreateList,
+  apiCreatePurchase,
+  apiCreateUser,
+  apiUpdateItem,
+  pageAsMember,
+} from "./helpers/factories.js";
+
+/**
+ * Each test sets up Alice + Bob (and sometimes Carol) on the same list,
+ * opens both pages with `pageAsMember` (which awaits the WebSocket open
+ * before returning), then triggers a mutation via the API and asserts that
+ * the *other* page's UI reflects the broadcast within 5s.
+ */
+test.describe("realtime", () => {
+  async function setupAliceAndBob(request: Parameters<typeof apiCreateList>[0]) {
+    const alice = await apiCreateUser(request, "Alice");
+    const bob = await apiCreateUser(request, "Bob");
+    const list = await apiCreateList(request, "Trip");
+    await apiAddMember(request, list.id, alice.id);
+    await apiAddMember(request, list.id, bob.id);
+    return { alice, bob, list };
+  }
+
+  test("item:added — Bob sees an item Alice added", async ({
+    browser,
+    request,
+  }) => {
+    const { alice, bob, list } = await setupAliceAndBob(request);
+    await pageAsMember(browser, alice, list);
+    const bobPage = await pageAsMember(browser, bob, list);
+
+    await apiAddItem(request, list.id, "Milk", alice.id);
+
+    await expect(bobPage.getByText("Milk")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("item:updated — Bob's row reflects a cart-state cycle", async ({
+    browser,
+    request,
+  }) => {
+    const { alice, bob, list } = await setupAliceAndBob(request);
+    const milk = await apiAddItem(request, list.id, "Milk", alice.id);
+    await pageAsMember(browser, alice, list);
+    const bobPage = await pageAsMember(browser, bob, list);
+
+    await apiUpdateItem(request, milk.id, { cartState: "purchased" });
+
+    await expect(
+      bobPage.getByRole("button", { name: /purchased \(1\)/i }),
+    ).toBeVisible({ timeout: 5000 });
+    const milkRow = bobPage.getByRole("listitem").filter({ hasText: "Milk" });
+    await expect(milkRow.getByText("Milk")).toHaveClass(/line-through/);
+  });
+
+  test("item:deleted — Bob's row drops when Alice deletes it", async ({
+    browser,
+    request,
+  }) => {
+    const { alice, bob, list } = await setupAliceAndBob(request);
+    const milk = await apiAddItem(request, list.id, "Milk", alice.id);
+    await pageAsMember(browser, alice, list);
+    const bobPage = await pageAsMember(browser, bob, list);
+
+    await expect(bobPage.getByText("Milk")).toBeVisible();
+
+    const res = await request.delete(`/api/items/${milk.id}`);
+    expect(res.ok()).toBeTruthy();
+
+    await expect(bobPage.getByText("Milk")).toHaveCount(0, { timeout: 5000 });
+  });
+
+  test("member:joined — Carol joining bumps the member count for Alice and Bob", async ({
+    browser,
+    request,
+  }) => {
+    const { alice, bob, list } = await setupAliceAndBob(request);
+    const alicePage = await pageAsMember(browser, alice, list);
+    const bobPage = await pageAsMember(browser, bob, list);
+
+    const carol = await apiCreateUser(request, "Carol");
+    await apiAddMember(request, list.id, carol.id);
+
+    await expect(
+      alicePage.getByRole("button", { name: /view members/i }),
+    ).toContainText("3 members", { timeout: 5000 });
+    await expect(
+      bobPage.getByRole("button", { name: /view members/i }),
+    ).toContainText("3 members", { timeout: 5000 });
+  });
+
+  test("member:left — Bob leaving drops his avatar from Alice's cluster", async ({
+    browser,
+    request,
+  }) => {
+    const { alice, bob, list } = await setupAliceAndBob(request);
+    const alicePage = await pageAsMember(browser, alice, list);
+    await pageAsMember(browser, bob, list);
+
+    const res = await request.delete(`/api/lists/${list.id}/members/${bob.id}`);
+    expect(res.ok()).toBeTruthy();
+
+    await expect(
+      alicePage.getByRole("button", { name: /view members/i }),
+    ).toContainText("1 member", { timeout: 5000 });
+  });
+
+  test("purchase:created — Bob's splits chip appears live", async ({
+    browser,
+    request,
+  }) => {
+    const { alice, bob, list } = await setupAliceAndBob(request);
+    const milk = await apiAddItem(request, list.id, "Milk", alice.id);
+    await pageAsMember(browser, alice, list);
+    const bobPage = await pageAsMember(browser, bob, list);
+
+    // No splits chip yet.
+    await expect(
+      bobPage.getByRole("button", { name: /view splits/i }),
+    ).toHaveCount(0);
+
+    await apiCreatePurchase(request, list.id, {
+      payerUserId: alice.id,
+      items: [{ itemId: milk.id, priceCents: 1000 }],
+    });
+
+    await expect(
+      bobPage.getByRole("button", { name: /view splits \(\$10\.00 total\)/i }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/share-and-join.spec.ts
+++ b/e2e/share-and-join.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "./fixtures.js";
+import {
+  apiAddMember,
+  apiCreateList,
+  apiCreateUser,
+  pageAsMember,
+  setSavedUser,
+} from "./helpers/factories.js";
+
+test.describe("share + join", () => {
+  test("Share button writes a /join/<token> URL with the correct origin to the clipboard", async ({
+    browser,
+    request,
+    baseURL,
+  }) => {
+    const context = await browser.newContext({
+      permissions: ["clipboard-read", "clipboard-write"],
+    });
+    const page = await context.newPage();
+
+    const alice = await apiCreateUser(request, "Alice");
+    const list = await apiCreateList(request, "Trip");
+    await apiAddMember(request, list.id, alice.id);
+
+    await page.goto("/");
+    await setSavedUser(page, alice);
+    await page.goto(`/list/${list.id}`);
+
+    await page.getByRole("button", { name: "Share list" }).click();
+    const url = await page.evaluate(() => navigator.clipboard.readText());
+    expect(url).toMatch(new RegExp(`^${baseURL}/join/.+$`));
+    expect(url).toContain(list.shareToken);
+  });
+
+  test("a brand-new user can join via the share link", async ({
+    browser,
+    request,
+  }) => {
+    const list = await apiCreateList(request, "Trip");
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(`/join/${list.shareToken}`);
+
+    await expect(
+      page.getByRole("heading", { name: /join "trip"/i }),
+    ).toBeVisible();
+
+    await page.locator("#user-name").fill("Bob");
+    await page.getByRole("button", { name: /^join list$/i }).click();
+    await page.waitForURL(/\/list\/\d+/);
+    await expect(page.getByRole("heading", { name: "Trip" })).toBeVisible();
+  });
+
+  test("a returning user with a saved identity sees a quick 'Join as <name>' button", async ({
+    browser,
+    request,
+  }) => {
+    const bob = await apiCreateUser(request, "Bob");
+    const list = await apiCreateList(request, "Trip");
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto("/");
+    await setSavedUser(page, bob);
+    await page.goto(`/join/${list.shareToken}`);
+
+    const rejoin = page.getByRole("button", { name: /^join as bob$/i });
+    await expect(rejoin).toBeVisible();
+    await rejoin.click();
+
+    await page.waitForURL(/\/list\/\d+/);
+    await expect(page.getByRole("heading", { name: "Trip" })).toBeVisible();
+  });
+
+  test("a user who's already a member is auto-redirected with replace:true", async ({
+    browser,
+    request,
+  }) => {
+    const alice = await apiCreateUser(request, "Alice");
+    const list = await apiCreateList(request, "Trip");
+    await apiAddMember(request, list.id, alice.id);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto("/"); // entry: home
+    await setSavedUser(page, alice);
+    await page.goto(`/join/${list.shareToken}`);
+
+    // Auto-redirect to /list/:id.
+    await page.waitForURL(new RegExp(`/list/${list.id}$`));
+    await expect(page.getByRole("heading", { name: "Trip" })).toBeVisible();
+
+    // Going back should skip the /join page (replace:true) and land at /.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+  });
+});


### PR DESCRIPTION
Closes #21. Final slice of the full E2E suite.

## Summary
- Four new spec files covering the multi-context flows and the remaining navigation/error cases:
  - `share-and-join.spec.ts` — clipboard write of the share URL, new-user join, quick rejoin, `replace:true` auto-redirect for already-a-member.
  - `members.spec.ts` — avatar-cluster overflow at 6 members, "(you)" marker, leave-list confirm + navigate.
  - `realtime.spec.ts` — `item:added`, `item:updated`, `item:deleted`, `member:joined`, `member:left`, `purchase:created` — each driven by an API mutation while two browser contexts watch the list.
  - `errors.spec.ts` — 404 list ID, invalid share token, read-only add-bar for a logged-out viewer.
- New `pageAsMember` helper that opens a context, seeds the user into localStorage, navigates to `/list/:id`, and awaits the WebSocket handshake before returning. Implemented by patching `WebSocket` via `addInitScript` to expose an "opened" promise — without this, API mutations triggered right after navigation race the WS handshake and the broadcast is silently dropped.

## Notes for future spec authors
- Native `confirm()` dialogs (used by MembersModal's "Leave list" path) need `page.once("dialog", d => d.accept())` registered *before* the click that triggers them.
- Clipboard tests need `permissions: ["clipboard-read", "clipboard-write"]` on the BrowserContext; the default `page` fixture's context doesn't have them.

## Test plan
- [x] `npm run typecheck` — clean.
- [x] `npm test` — 18 client + server tests pass, unchanged.
- [x] `npm run test:e2e` — 55 tests pass (39 existing + 16 new), ~48s per run.
- [x] Realtime spec: 10 consecutive clean runs locally (issue acceptance criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)